### PR TITLE
Update API and DRY up class

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,1 +1,2 @@
 *.gem
+vendor/bundle

--- a/commonregex.gemspec
+++ b/commonregex.gemspec
@@ -1,11 +1,17 @@
+# -*- encoding: utf-8 -*-
+
+$:.unshift File.expand_path("../lib", __FILE__)
+
+require "commonregex/version"
+
 Gem::Specification.new do |s|
   s.name        = 'commonregex'
-  s.version     = '0.0.2'
-  s.license       = 'MIT'
+  s.version     = CommonRegex::VERSION
+  s.license     = 'MIT'
   s.summary     = "CommonRegex port for Ruby"
   s.description = "Find a lot of kinds of common information in a string. CommonRegex port for Ruby."
   s.authors     = ["Talysson Oliveira Cassiano"]
   s.email       = 'talyssonoc@gmail.com'
-  s.files       = ["lib/commonregex.rb"]
+  s.files       = ["lib/commonregex.rb", "lib/commonregex/version.rb"]
   s.homepage    = 'https://github.com/talyssonoc/CommonRegexRuby'
 end

--- a/lib/commonregex.rb
+++ b/lib/commonregex.rb
@@ -65,3 +65,4 @@ class CommonRegex
 
 end
 
+require "commonregex/version"

--- a/lib/commonregex.rb
+++ b/lib/commonregex.rb
@@ -1,106 +1,67 @@
 class CommonRegex
 
-	# Methods used to generate @date_regex
-	def self.opt (regex)
-		'(?:' + regex + ')?'
-	end
+  # Methods used to generate @date_regex
+  def self.opt(regex)
+    '(?:' + regex + ')?'
+  end
 
-	def self.group(regex)
-		'(?:' + regex + ')'
-	end
+  def self.group(regex)
+    '(?:' + regex + ')'
+  end
 
-	def self.any(regexes)
-		regexes.join('|')
-	end
+  def self.any(regexes)
+    regexes.join('|')
+  end
 
-	# Generate @date_regex
-	month_regex = '(?:jan\\.?|january|feb\\.?|february|mar\\.?|march|apr\\.?|april|may|jun\\.?|june|jul\\.?|july|aug\\.?|august|sep\\.?|september|oct\\.?|october|nov\\.?|november|dec\\.?|december)'
-	day_regex = '[0-3]?\\d(?:st|nd|rd|th)?'
-	year_regex = '\\d{4}'
+  # Generate @date_regex
+  month_regex = '(?:jan\\.?|january|feb\\.?|february|mar\\.?|march|apr\\.?|april|may|jun\\.?|june|jul\\.?|july|aug\\.?|august|sep\\.?|september|oct\\.?|october|nov\\.?|november|dec\\.?|december)'
+  day_regex = '[0-3]?\\d(?:st|nd|rd|th)?'
+  year_regex = '\\d{4}'
 
-	@@date_regex = Regexp.new('(' + CommonRegex.group(
-		CommonRegex.any(
-			[
-				day_regex + '\\s+(?:of\\s+)?' + month_regex,
-				month_regex + '\\s+' + day_regex
-			]
-		)
-	) + '(?:\\,)?\\s*' + CommonRegex.opt(year_regex) + '|[0-3]?\\d[-/][0-3]?\\d[-/]\\d{2,4})', Regexp::IGNORECASE || Regexp::MULTILINE)
+  @@dates_regex = Regexp.new('(' + CommonRegex.group(
+    CommonRegex.any(
+      [
+        day_regex + '\\s+(?:of\\s+)?' + month_regex,
+        month_regex + '\\s+' + day_regex
+      ]
+    )
+  ) + '(?:\\,)?\\s*' + CommonRegex.opt(year_regex) + '|[0-3]?\\d[-/][0-3]?\\d[-/]\\d{2,4})', Regexp::IGNORECASE || Regexp::MULTILINE)
 
-	@@time_regex = /\b((0?[0-9]|1[0-2])(:[0-5][0-9])?(am|pm)|([01]?[0-9]|2[0-3]):[0-5][0-9])/im
-	@@phone_regex = /(\d?[^\s\w]*(?:\(?\d{3}\)?\W*)?\d{3}\W*\d{4})/im
-	@@links_regex = /((?:https?:\/\/|www\d{0,3}[.]|[a-z0-9.\-]+[.][a-z]{2,4}\/)(?:[^\s()<>]+|\((?:[^\s()<>]+|(?:\([^\s()<>]+\)))*\))+(?:\((?:[^\s()<>]+|(?:\([^\s()<>]+\)))*@\)|[^\s`!()\[\]{};:\'".,<>?]))/im
-	@@emails_regex = /([a-z0-9!#$%&'*+\/=?\^_`{|}~\-]+@([a-z0-9]+\.)+([a-z0-9]+))/im
-	@@ipv4_regex = /\b(((25[0-5]|2[0-4][0-9]|[01]?[0-9][0-9]?)\.){3}(25[0-5]|2[0-4][0-9]|[01]?[0-9][0-9]?))\b/m
-	@@ipv6_regex = /((([0-9A-Fa-f]{1,4}:){7}[0-9A-Fa-f]{1,4})|(([0-9A-Fa-f]{1,4}:){6}:[0-9A-Fa-f]{1,4})|(([0-9A-Fa-f]{1,4}:){5}:([0-9A-Fa-f]{1,4}:)?[0-9A-Fa-f]{1,4})|(([0-9A-Fa-f]{1,4}:){4}:([0-9A-Fa-f]{1,4}:){0,2}[0-9A-Fa-f]{1,4})|(([0-9A-Fa-f]{1,4}:){3}:([0-9A-Fa-f]{1,4}:){0,3}[0-9A-Fa-f]{1,4})|(([0-9A-Fa-f]{1,4}:){2}:([0-9A-Fa-f]{1,4}:){0,4}[0-9A-Fa-f]{1,4})|(([0-9A-Fa-f]{1,4}:){6}((\b((25[0-5])|(1\d{2})|(2[0-4]\d)|(\d{1,2}))\b)\.){3}(\b((25[0-5])|(1\d{2})|(2[0-4]\d)|(\d{1,2}))\b))|(([0-9A-Fa-f]{1,4}:){0,5}:((\b((25[0-5])|(1\d{2})|(2[0-4]\d)|(\d{1,2}))\b)\.){3}(\b((25[0-5])|(1\d{2})|(2[0-4]\d)|(\d{1,2}))\b))|(::([0-9A-Fa-f]{1,4}:){0,5}((\b((25[0-5])|(1\d{2})|(2[0-4]\d)|(\d{1,2}))\b)\.){3}(\b((25[0-5])|(1\d{2})|(2[0-4]\d)|(\d{1,2}))\b))|([0-9A-Fa-f]{1,4}::([0-9A-Fa-f]{1,4}:){0,5}[0-9A-Fa-f]{1,4})|(::([0-9A-Fa-f]@{1,4}:){0,6}[0-9A-Fa-f]{1,4})|(([0-9A-Fa-f]{1,4}:){1,7}:))\b/im
-	@@hex_colors_regex = /(#(?:[0-9a-fA-F]{3}){1,2})\b/im
-	@@acronyms_regex = /\b(([A-Z]\.)+|([A-Z]){2,})/m
-	@@money_regex = /(((^|\b)US?)?\$\s?[0-9]{1,3}((,[0-9]{3})+|([0-9]{3})+)?(\.[0-9]{1,2})?\b)/m
-	@@percentage_regex = /((100(\.0+)?|[0-9]{1,2}(\.[0-9]+)?)%)/m
-	@@credit_card_regex = /((?:(?:\d{4}[- ]){3}\d{4}|\d{16}))(?![\d])/m
-	@@address_regex = /(\d{1,4} [\w\s]{1,20}(?:(street|avenue|road|highway|square|traill|drive|court|parkway|boulevard)\b|(st|ave|rd|hwy|sq|trl|dr|ct|pkwy|blvd)\.(?=\b)?))/im
+  @@acronyms_regex = /\b(([A-Z]\.)+|([A-Z]){2,})/m
+  @@addresses_regex = /(\d{1,4} [\w\s]{1,20}(?:(street|avenue|road|highway|square|traill|drive|court|parkway|boulevard)\b|(st|ave|rd|hwy|sq|trl|dr|ct|pkwy|blvd)\.(?=\b)?))/im
+  @@credit_cards_regex = /((?:(?:\d{4}[- ]){3}\d{4}|\d{16}))(?![\d])/m
+  @@emails_regex = /([a-z0-9!#$%&'*+\/=?\^_`{|}~\-]+@([a-z0-9]+\.)+([a-z0-9]+))/im
+  @@hex_colors_regex = /(#(?:[0-9a-fA-F]{3}){1,2})\b/im
+  @@ipv4_regex = /\b(((25[0-5]|2[0-4][0-9]|[01]?[0-9][0-9]?)\.){3}(25[0-5]|2[0-4][0-9]|[01]?[0-9][0-9]?))\b/m
+  @@ipv6_regex = /((([0-9A-Fa-f]{1,4}:){7}[0-9A-Fa-f]{1,4})|(([0-9A-Fa-f]{1,4}:){6}:[0-9A-Fa-f]{1,4})|(([0-9A-Fa-f]{1,4}:){5}:([0-9A-Fa-f]{1,4}:)?[0-9A-Fa-f]{1,4})|(([0-9A-Fa-f]{1,4}:){4}:([0-9A-Fa-f]{1,4}:){0,2}[0-9A-Fa-f]{1,4})|(([0-9A-Fa-f]{1,4}:){3}:([0-9A-Fa-f]{1,4}:){0,3}[0-9A-Fa-f]{1,4})|(([0-9A-Fa-f]{1,4}:){2}:([0-9A-Fa-f]{1,4}:){0,4}[0-9A-Fa-f]{1,4})|(([0-9A-Fa-f]{1,4}:){6}((\b((25[0-5])|(1\d{2})|(2[0-4]\d)|(\d{1,2}))\b)\.){3}(\b((25[0-5])|(1\d{2})|(2[0-4]\d)|(\d{1,2}))\b))|(([0-9A-Fa-f]{1,4}:){0,5}:((\b((25[0-5])|(1\d{2})|(2[0-4]\d)|(\d{1,2}))\b)\.){3}(\b((25[0-5])|(1\d{2})|(2[0-4]\d)|(\d{1,2}))\b))|(::([0-9A-Fa-f]{1,4}:){0,5}((\b((25[0-5])|(1\d{2})|(2[0-4]\d)|(\d{1,2}))\b)\.){3}(\b((25[0-5])|(1\d{2})|(2[0-4]\d)|(\d{1,2}))\b))|([0-9A-Fa-f]{1,4}::([0-9A-Fa-f]{1,4}:){0,5}[0-9A-Fa-f]{1,4})|(::([0-9A-Fa-f]@{1,4}:){0,6}[0-9A-Fa-f]{1,4})|(([0-9A-Fa-f]{1,4}:){1,7}:))\b/im
+  @@links_regex = /((?:https?:\/\/|www\d{0,3}[.]|[a-z0-9.\-]+[.][a-z]{2,4}\/)(?:[^\s()<>]+|\((?:[^\s()<>]+|(?:\([^\s()<>]+\)))*\))+(?:\((?:[^\s()<>]+|(?:\([^\s()<>]+\)))*@\)|[^\s`!()\[\]{};:\'".,<>?]))/im
+  @@money_regex = /(((^|\b)US?)?\$\s?[0-9]{1,3}((,[0-9]{3})+|([0-9]{3})+)?(\.[0-9]{1,2})?\b)/m
+  @@percentages_regex = /((100(\.0+)?|[0-9]{1,2}(\.[0-9]+)?)%)/m
+  @@phones_regex = /(\d?[^\s\w]*(?:\(?\d{3}\)?\W*)?\d{3}\W*\d{4})/im
+  @@times_regex = /\b((0?[0-9]|1[0-2])(:[0-5][0-9])?(am|pm)|([01]?[0-9]|2[0-3]):[0-5][0-9])/im
 
-	
-	def initialize(text = '')
-		@text = text;
-	end
+  %w{acronyms addresses credit_cards dates emails hex_colors ipv4 ipv6 links
+    money percentages phones times}.each do |regex|
+    class_eval <<-RUBY.gsub(/^\s{6}/, ''), __FILE__, __LINE__
+      def self.get_#{regex}(text)
+        get_matches(text, @@#{regex}_regex)
+      end
 
-	def get_dates(text = @text)
-		get_matches(text, @@date_regex)
-	end
+      def get_#{regex}
+        self.class.get_#{regex}(@text)
+      end
+    RUBY
+  end
 
-	def get_times(text = @text)
-		get_matches(text, @@time_regex)
-	end
+  def initialize(text = '')
+    @text = text;
+  end
 
-	def get_phones(text = @text)
-		get_matches(text, @@phone_regex)
-	end
+  private
 
-	def get_links(text = @text)
-		get_matches(text, @@links_regex)
-	end
-
-	def get_emails(text = @text)
-		get_matches(text, @@emails_regex)
-	end
-
-	def get_ipv4(text = @text)
-		get_matches(text, @@ipv4_regex)
-	end
-
-	def get_ipv6(text = @text)
-		get_matches(text, @@ipv6_regex)
-	end
-
-	def get_hex_colors(text = @text)
-		get_matches(text, @@hex_colors_regex)
-	end
-
-	def get_acronyms(text = @text)
-		get_matches(text, @@acronyms_regex)
-	end
-
-	def get_money(text = @text)
-		get_matches(text, @@money_regex)
-	end
-
-	def get_percentages(text = @text)
-		get_matches(text, @@percentage_regex)
-	end
-
-	def get_credit_cards(text = @text)
-		get_matches(text, @@credit_card_regex)
-	end
-
-	def get_addresses(text = @text)
-		get_matches(text, @@address_regex)
-	end
-
-private
-	
-	def get_matches(text, regex)
-		text.scan(regex).collect{|x| x[0]}
-	end
+  def self.get_matches(text, regex)
+    text.scan(regex).collect{|x| x[0]}
+  end
 
 end
+

--- a/lib/commonregex/version.rb
+++ b/lib/commonregex/version.rb
@@ -1,0 +1,3 @@
+class CommonRegex
+  VERSION = '0.1.0'
+end

--- a/test/test_commonregex.rb
+++ b/test/test_commonregex.rb
@@ -2,26 +2,27 @@ gem 'minitest'
 
 require 'minitest/autorun'
 
-require_relative '../lib/commonregex'
+$:.unshift File.expand_path("../lib", File.dirname(__FILE__))
+require 'commonregex'
 
 class TestCommonRegex < Minitest::Test
-	def setup
-		@text = "John, please get that article on www.linkedin.com to me by 5:00PM\n"\
-			"on Jan 9th 2012. 4:00 would be ideal, actually. If you have any questions,\n"\
-			"you can reach my associate at (012)-345-6789 or associative@mail.com.\n"\
-			"I\'ll be on UK during the whole week on a J.R.R. Tolkien convention, starting friday at 4PM."
+  def setup
+    @text = "John, please get that article on www.linkedin.com to me by 5:00PM\n"\
+      "on Jan 9th 2012. 4:00 would be ideal, actually. If you have any questions,\n"\
+      "you can reach my associate at (012)-345-6789 or associative@mail.com.\n"\
+      "I\'ll be on UK during the whole week on a J.R.R. Tolkien convention, starting friday at 4PM."
 
-		@common_regex = CommonRegex.new(@text)
-	end
+    @common_regex = CommonRegex.new(@text)
+  end
 
-	def test_dates
+  def test_dates
     assert_equal @common_regex.get_dates, ['Jan 9th 2012']
-	end
+  end
 
   def test_times
     assert_equal @common_regex.get_times, ['5:00PM', '4:00', '4PM']
   end
- 
+
   def test_phones
     assert_equal @common_regex.get_phones, ['(012)-345-6789']
   end
@@ -35,15 +36,15 @@ class TestCommonRegex < Minitest::Test
   end
 
   def test_ipv4
-    assert_equal @common_regex.get_ipv4('The IPv4 address for localhost is 127.0.0.1'), ['127.0.0.1']
+    assert_equal CommonRegex.get_ipv4('The IPv4 address for localhost is 127.0.0.1'), ['127.0.0.1']
   end
 
   def test_ipv6
-    assert_equal @common_regex.get_ipv6('The IPv6 address for localhost is 0:0:0:0:0:0:0:1, or alternatively ::1, but not :1:.'), ['0:0:0:0:0:0:0:1', '::1']
+    assert_equal CommonRegex.get_ipv6('The IPv6 address for localhost is 0:0:0:0:0:0:0:1, or alternatively ::1, but not :1:.'), ['0:0:0:0:0:0:0:1', '::1']
   end
 
   def test_hex_colors
-    assert_equal @common_regex.get_hex_colors('Did you knew that Hacker News orange is #ff6600?'), ['#ff6600']
+    assert_equal CommonRegex.get_hex_colors('Did you knew that Hacker News orange is #ff6600?'), ['#ff6600']
   end
 
   def test_acronyms
@@ -51,30 +52,30 @@ class TestCommonRegex < Minitest::Test
   end
 
   def test_money
-    assert_equal @common_regex.get_money('They said the price was US$5,000.90, actually it is US$3,900.5. It\'s $1100.4 less, can you imagine this?'),
-    																		['US$5,000.90', 'US$3,900.5', '$1100.4']
+    assert_equal CommonRegex.get_money('They said the price was US$5,000.90, actually it is US$3,900.5. It\'s $1100.4 less, can you imagine this?'),
+                                        ['US$5,000.90', 'US$3,900.5', '$1100.4']
   end
 
   def test_percentages
-    assert_equal @common_regex.get_percentages('I\'m 99.9999999% sure that I\'ll get a raise of 5%.'), ['99.9999999%', '5%']
+    assert_equal CommonRegex.get_percentages('I\'m 99.9999999% sure that I\'ll get a raise of 5%.'), ['99.9999999%', '5%']
   end
 
-	def test_credit_cards
-		assert_equal @common_regex.get_credit_cards('His credit card number can be writen as 1234567891011121 or 1234-5678-9101-1121, but not 123-4567891011121.'),
-																								['1234567891011121', '1234-5678-9101-1121']
-	end
+  def test_credit_cards
+    assert_equal CommonRegex.get_credit_cards('His credit card number can be writen as 1234567891011121 or 1234-5678-9101-1121, but not 123-4567891011121.'),
+                                                ['1234567891011121', '1234-5678-9101-1121']
+  end
 
-	def test_addresses
-		text = 'checkout the new place at 101 main st., 504 parkwood drive, 3 elm boulevard, 500 elm street, 101 main straight';
-		
-		matches = [
-		'101 main st.',
-		'504 parkwood drive',
-		'3 elm boulevard',
-		'500 elm street'
-		];
+  def test_addresses
+    text = 'checkout the new place at 101 main st., 504 parkwood drive, 3 elm boulevard, 500 elm street, 101 main straight';
 
-	  assert_equal @common_regex.get_addresses(text), matches
-	end
+    matches = [
+    '101 main st.',
+    '504 parkwood drive',
+    '3 elm boulevard',
+    '500 elm street'
+    ];
+
+    assert_equal CommonRegex.get_addresses(text), matches
+  end
 
 end


### PR DESCRIPTION
This pull request does two things
1. It changes the API.
   Text can now only be passed to class methods or an instance can be created with a supplied text, i.e.

``` ruby
   > CommonRegex.get_dates "11-12-2013"
   => ["11-12-2013"]
   > common_regex = CommonRegex.new("11-12-2013")
   > common_regex.get_dates
   => ["11-12-2013"]
```
1. It cleans up the class definition by using class_eval to dynamically create class and instance methods.
